### PR TITLE
Fix heap buffer overflow in setVersionInfo

### DIFF
--- a/iOSSDK2.0_NISDK/NISDK/n2base/penComm/NJPenCommParser.m
+++ b/iOSSDK2.0_NISDK/NISDK/n2base/penComm/NJPenCommParser.m
@@ -3074,7 +3074,7 @@ static int length4Speed;
     memset(appVer, 0, sizeof(appVer));
     NSString *inputStr = [MyFunctions appVersion];;
     NSData *stringData = [inputStr dataUsingEncoding:NSUTF8StringEncoding];
-    memcpy(appVer, [stringData bytes], sizeof(stringData));
+    memcpy(appVer, [stringData bytes], [stringData length]);
     [tempPacketData appendBytes:&appVer length:sizeof(appVer)];
     
     unsigned char *tempDataBytes = (unsigned char *)[tempPacketData bytes];


### PR DESCRIPTION
I caught this bug running the connection code with the address sanitizer turned on.

`sizeof` returns the size of the object representation of the type argument at
compile time. This can differ from the actual size of `[stringData bytes]` depending on
the length of the string. If the string used to construct the data was smaller than the
value returned by `sizeof`, this memcopy will read beyond the `stringData` buffer and
copy potentially unitialized/garbage data into `appVer`.

`[stringData length]` will return the actual length of the buffer provided by
`[stringData bytes]`